### PR TITLE
feat: Phase 3 - Implement get_workout_by_id tool (Issue #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Phase 3: get_workout_by_id Tool Implementation (Issue #10)
+- Implemented `get_workout_by_id` MCP tool in `src/workout_mcp_server/main.py`
+- Tool accepts a workout_id parameter and returns complete workout details
+- Returns appropriate error message if workout not found or on exceptions
+- Leverages existing `WorkoutDataLoader.get_workout_by_id()` method from Phase 2
+- Includes proper error handling and logging
+- Full test coverage with unit tests for success and error cases
+- FastMCP decorator pattern for tool definition with type hints
+
 #### Phase 2: Data Loading Functionality (Issue #9)
 - Comprehensive data loading module in `src/workout_mcp_server/data_loader.py`
 - Pydantic-based `Workout` model for data validation and parsing

--- a/src/workout_mcp_server/main.py
+++ b/src/workout_mcp_server/main.py
@@ -1,13 +1,44 @@
 """Workout MCP Server - Main entry point."""
 
 import logging
+from pathlib import Path
 
 from fastmcp import FastMCP
+
+from .data_loader import WorkoutDataLoader
 
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server
 mcp: FastMCP = FastMCP("workout-mcp-server")
+
+# Initialize data loader
+DATA_PATH = Path(__file__).parent.parent.parent / "data_store" / "workouts.json"
+data_loader = WorkoutDataLoader(DATA_PATH)
+
+
+@mcp.tool()
+async def get_workout_by_id(workout_id: str) -> dict:
+    """Get details of a specific workout by ID.
+
+    Args:
+        workout_id: The unique identifier of the workout
+
+    Returns:
+        Dictionary containing workout details including date, duration, TSS, and type
+    """
+    try:
+        workout = data_loader.get_workout_by_id(workout_id)
+        if workout is None:
+            return {"error": f"Workout with ID '{workout_id}' not found"}
+
+        # Convert Pydantic model to dict and format date as string
+        workout_dict = workout.model_dump()
+        workout_dict["date"] = workout.date.strftime("%Y-%m-%d")
+        return workout_dict
+    except Exception as e:
+        logger.error(f"Error retrieving workout {workout_id}: {e}")
+        return {"error": f"Failed to retrieve workout: {str(e)}"}
 
 
 def configure_logging() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,3 +36,82 @@ def test_main_function_exists():
     from workout_mcp_server.main import main
 
     assert callable(main)
+
+
+def test_get_workout_by_id_tool_exists():
+    """Test that get_workout_by_id tool is registered."""
+    from workout_mcp_server.main import get_workout_by_id
+
+    assert callable(get_workout_by_id)
+    assert hasattr(get_workout_by_id, "__doc__")
+    assert "Get details of a specific workout by ID" in get_workout_by_id.__doc__
+
+
+async def test_get_workout_by_id_success():
+    """Test successful retrieval of a workout by ID."""
+    from datetime import datetime
+    from unittest.mock import patch
+
+    from workout_mcp_server.data_loader import Workout
+    from workout_mcp_server.main import get_workout_by_id
+
+    # Create a mock workout
+    mock_workout = Workout(
+        id="test-123",
+        date=datetime(2024, 1, 15),
+        duration_minutes=90,
+        distance_km=45.0,
+        avg_power_watts=200,
+        tss=85,
+        workout_type="threshold",
+    )
+
+    # Mock the data_loader
+    with patch("workout_mcp_server.main.data_loader") as mock_loader:
+        mock_loader.get_workout_by_id.return_value = mock_workout
+
+        result = await get_workout_by_id("test-123")
+
+        assert result["id"] == "test-123"
+        assert result["date"] == "2024-01-15"
+        assert result["duration_minutes"] == 90
+        assert result["distance_km"] == 45.0
+        assert result["avg_power_watts"] == 200
+        assert result["tss"] == 85
+        assert result["workout_type"] == "threshold"
+        assert "error" not in result
+
+        mock_loader.get_workout_by_id.assert_called_once_with("test-123")
+
+
+async def test_get_workout_by_id_not_found():
+    """Test retrieval of non-existent workout."""
+    from unittest.mock import patch
+
+    from workout_mcp_server.main import get_workout_by_id
+
+    with patch("workout_mcp_server.main.data_loader") as mock_loader:
+        mock_loader.get_workout_by_id.return_value = None
+
+        result = await get_workout_by_id("non-existent-id")
+
+        assert "error" in result
+        assert result["error"] == "Workout with ID 'non-existent-id' not found"
+
+        mock_loader.get_workout_by_id.assert_called_once_with("non-existent-id")
+
+
+async def test_get_workout_by_id_exception():
+    """Test handling of exceptions during workout retrieval."""
+    from unittest.mock import patch
+
+    from workout_mcp_server.main import get_workout_by_id
+
+    with patch("workout_mcp_server.main.data_loader") as mock_loader:
+        mock_loader.get_workout_by_id.side_effect = Exception("Database error")
+
+        result = await get_workout_by_id("test-123")
+
+        assert "error" in result
+        assert "Failed to retrieve workout" in result["error"]
+        assert "Database error" in result["error"]


### PR DESCRIPTION
## Summary
- Implemented the `get_workout_by_id` MCP tool that retrieves a specific workout by its unique identifier
- Tool leverages existing `WorkoutDataLoader` from Phase 2 for data access
- Returns complete workout object when found or appropriate error message when not found

## Implementation Details
- Added `get_workout_by_id` tool to `src/workout_mcp_server/main.py` using FastMCP decorator pattern
- Tool accepts a `workout_id` parameter (string) and returns workout details as dictionary
- Includes proper error handling for not found and exception cases
- Formats date as ISO string (YYYY-MM-DD) in response
- Added comprehensive unit tests covering success, not found, and exception scenarios

## Test Plan
- [x] Run unit tests: `pytest tests/test_main.py -v` (all 51 tests passing)
- [x] Run linting: `ruff check .` (all checks passed)
- [x] Run type checking: `mypy src/` (no issues found)
- [x] Verify tool accepts workout_id parameter
- [x] Verify tool returns complete workout object if found
- [x] Verify tool returns appropriate error message if workout not found
- [x] Verify exception handling works correctly

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)