### PR TITLE
Implement compute_form tool for TSB calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Phase 6: compute_form Tool Implementation (Issue #16)
+- Implemented `compute_form` MCP tool for Training Stress Balance (TSB) calculation
+- TSB calculated as the difference between CTL (fitness) and ATL (fatigue)
+- Tool accepts target_date parameter and returns TSB with interpretation
+- Interpretation of TSB values:
+  - TSB > 5: Fresh - Good readiness for hard training or competition
+  - TSB between -5 and 5: Neutral - Balanced training load
+  - TSB < -5: Fatigued - Consider recovery or lighter training
+- Reuses existing compute_fitness and compute_fatigue tools internally
+- Returns combined metadata including CTL, ATL, and workouts count
+- Comprehensive error handling propagates errors from dependent tools
+- Full test coverage with 9 new unit tests covering all scenarios
+- FastMCP decorator pattern with async/await for tool composition
+- Mathematical formula: TSB = CTL - ATL (positive = fresh, negative = fatigued)
+
 #### Phase 5: compute_fatigue Tool Implementation (Issue #15)
 - Implemented `compute_fatigue` MCP tool for Acute Training Load (ATL) calculation
 - ATL calculated as 7-day exponentially weighted moving average of TSS values

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,16 +69,16 @@ Follow behavior-driven testing (ADR-001):
 
 ## Implementation Status
 
-Currently skeleton only - `src/workout_mcp_server/main.py` needs to be replaced with actual MCP server implementation using FastMCP. The following tools need to be implemented according to README:
-1. `get_last_50_workouts` - Retrieves all 50 workouts, sorted by date (most recent first)
-2. `get_last_7_workouts` - Retrieves the 7 most recent workouts
-3. `get_workout_by_id` - Retrieves specific workout by ID
-4. `compute_fitness` - Calculates CTL (42-day EWMA of TSS)
-5. `compute_fatigue` - Calculates ATL (7-day EWMA of TSS)
-6. `compute_form` - Calculates TSB (CTL - ATL)
+All MCP tools have been implemented:
+1. `get_last_50_workouts` - ✓ Retrieves all 50 workouts, sorted by date (most recent first)
+2. `get_last_7_workouts` - ✓ Retrieves the 7 most recent workouts
+3. `get_workout_by_id` - ✓ Retrieves specific workout by ID
+4. `compute_fitness` - ✓ Calculates CTL (42-day EWMA of TSS)
+5. `compute_fatigue` - ✓ Calculates ATL (7-day EWMA of TSS)
+6. `compute_form` - ✓ Calculates TSB (CTL - ATL)
 
 ## Key Files
-- `src/workout_mcp_server/main.py` - Main MCP server implementation (needs to be written)
+- `src/workout_mcp_server/main.py` - Main MCP server implementation
 - `src/workout_mcp_server/tools/` - Directory for tool implementations
 - `data_store/workouts.json` - Mock workout data
 - `tests/` - Test files following pytest conventions


### PR DESCRIPTION
## Summary
- Implements the `compute_form` MCP tool to calculate Training Stress Balance (TSB)
- Completes Phase 6 of the workout MCP server implementation
- All 6 planned MCP tools are now fully implemented

## Changes
- Add `compute_form` tool that calculates TSB as CTL - ATL
- Provides athlete form/freshness interpretation based on TSB value
- Reuses existing `compute_fitness` and `compute_fatigue` tools internally
- Comprehensive error handling with error propagation from dependent tools
- Add 9 unit tests covering all scenarios (success, errors, edge cases)
- Update CLAUDE.md to reflect all tools are implemented
- Update CHANGELOG.md with implementation details

## Test plan
- [x] Run all tests: `pytest` - 95 tests pass
- [x] Run linting: `ruff check .` - no issues
- [x] Run type checking: `mypy src/` - no issues
- [x] Run formatting: `black .` - all files formatted
- [x] Manual testing of compute_form tool functionality

🤖 Generated with [Claude Code](https://claude.ai/code)