### PR TITLE
Fix doc typo

### DIFF
--- a/ai_docs/building-mcp-with-llms.md
+++ b/ai_docs/building-mcp-with-llms.md
@@ -6481,7 +6481,7 @@ This tutorial will primarily focus on tools.
     }
     ```
 
-    Uses the the `MethodToolCallbackProvider` utils to convert the `@Tools` into actionable callbacks used by the MCP server.
+    Uses the `MethodToolCallbackProvider` utils to convert the `@Tools` into actionable callbacks used by the MCP server.
 
     ### Running the server
 


### PR DESCRIPTION
## Summary
- remove duplicate "the" in MCP building guide

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5798e09083229cb28b02ffcbe053