### PR TITLE
Fix filtering bug in fitness metrics

### DIFF
--- a/src/workout_mcp_server/main.py
+++ b/src/workout_mcp_server/main.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from fastmcp import FastMCP
+from fastmcp import FastMCP  # type: ignore[import]
 
 from .data_loader import WorkoutDataLoader
 from .tools.fitness_metrics import calculate_ewma, get_workouts_for_ctl_calculation
@@ -35,7 +35,7 @@ async def get_workout_by_id(workout_id: str) -> dict:
             return {"error": f"Workout with ID '{workout_id}' not found"}
 
         # Convert Pydantic model to dict and format date as string
-        workout_dict = workout.model_dump()
+        workout_dict = workout.model_dump()  # type: ignore[attr-defined]
         workout_dict["date"] = workout.date.strftime("%Y-%m-%d")
         return workout_dict
     except Exception as e:
@@ -61,7 +61,7 @@ async def get_last_7_workouts() -> list[dict] | dict:
         # Convert each workout to dict format with date as string
         result = []
         for workout in recent_workouts:
-            workout_dict = workout.model_dump()
+            workout_dict = workout.model_dump()  # type: ignore[attr-defined]
             workout_dict["date"] = workout.date.strftime("%Y-%m-%d")
             result.append(workout_dict)
 
@@ -86,7 +86,7 @@ async def get_last_50_workouts() -> list[dict] | dict:
         # Convert each workout to dict format with date as string
         result = []
         for workout in workouts:
-            workout_dict = workout.model_dump()
+            workout_dict = workout.model_dump()  # type: ignore[attr-defined]
             workout_dict["date"] = workout.date.strftime("%Y-%m-%d")
             result.append(workout_dict)
 

--- a/src/workout_mcp_server/tools/fitness_metrics.py
+++ b/src/workout_mcp_server/tools/fitness_metrics.py
@@ -2,7 +2,7 @@
 
 import math
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from ..data_loader import Workout
 
@@ -51,14 +51,17 @@ def get_workouts_for_ctl_calculation(
     Returns:
         List of workouts within the specified time window, sorted chronologically
     """
-    # Filter workouts up to and including target date
+    # Determine start date of the window
+    start_date = target_date - timedelta(days=days - 1)
+
+    # Filter workouts within the window [start_date, target_date]
     relevant_workouts = [
-        workout for workout in workouts if workout.date.date() <= target_date.date()
+        workout
+        for workout in workouts
+        if start_date.date() <= workout.date.date() <= target_date.date()
     ]
 
     # Sort by date (oldest first) for EWMA calculation
     relevant_workouts.sort(key=lambda w: w.date)
 
-    # Return all workouts if we have fewer than the desired window
-    # This allows gradual buildup of fitness metrics for new athletes
     return relevant_workouts

--- a/tests/test_fitness_metrics.py
+++ b/tests/test_fitness_metrics.py
@@ -166,10 +166,9 @@ class TestGetWorkoutsForCtlCalculation:
 
         result = get_workouts_for_ctl_calculation(workouts, target_date)
 
-        # Should return all workouts up to and including target date
-        # Days 0-59 (inclusive) = 60 workouts
-        assert len(result) == 60
-        assert result[0].date.date() == datetime(2024, 1, 1).date()
+        # Should return workouts within the 42-day window
+        assert len(result) == 42
+        assert result[0].date.date() == datetime(2024, 1, 19).date()
         assert result[-1].date.date() == datetime(2024, 2, 29).date()
 
     def test_different_time_constants(self):
@@ -189,3 +188,20 @@ class TestGetWorkoutsForCtlCalculation:
         # Both should return same workouts since all are within 7 days
         assert len(result_7day) == len(result_42day) == 3
         assert result_7day == result_42day
+
+    def test_respects_days_parameter(self):
+        """Test that the days parameter limits the returned workouts."""
+        # Create 10 sequential workouts
+        workouts = []
+        base_date = datetime(2024, 1, 1)
+        for i in range(10):
+            workout_date = base_date + timedelta(days=i)
+            workouts.append(self.create_workout(workout_date.strftime("%Y-%m-%d")))
+
+        target_date = datetime(2024, 1, 10)
+
+        result = get_workouts_for_ctl_calculation(workouts, target_date, days=5)
+
+        assert len(result) == 5
+        assert result[0].date.date() == datetime(2024, 1, 6).date()
+        assert result[-1].date.date() == datetime(2024, 1, 10).date()


### PR DESCRIPTION
## Summary
- ensure `get_workouts_for_ctl_calculation` limits workouts to the configured window
- ignore mypy issues for external libraries
- adjust tests for the new behaviour and add a regression test

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f565481ec832293e2fb3f0259a04a